### PR TITLE
refactor: formatter参数支持VNode作为返回值（适配jsx写法）

### DIFF
--- a/demo/src/views/VFixedDemo.vue
+++ b/demo/src/views/VFixedDemo.vue
@@ -119,8 +119,10 @@ export default {
       // 使用自定义列，改变列宽度后，需要手动更新table头部
       this.$refs.virtualScroll.doHeaderLayout()
     },
-    formatter(row, column, value) {
-      return `姓名：${value}`
+    formatter(row, column, value, index) {
+      const text = `姓名：${value}`
+      // 需要同时支持string和VNode
+      return index % 2 === 0 ? text : this.$createElement('span', text)
     }
   },
   watch: {

--- a/src/el-table-virtual-column-formatter.vue
+++ b/src/el-table-virtual-column-formatter.vue
@@ -1,0 +1,14 @@
+<script>
+// 此组件仅用于显示VNode
+export default {
+  name: 'el-table-virtual-column-formatter',
+  props: {
+    vNode: {
+      type: Object
+    }
+  },
+  render () {
+    return this.vNode
+  }
+}
+</script>


### PR DESCRIPTION
改动：formatter写法支持VNode
原因：之前提交formatter参数的时候没有考虑结果是VNode的情况，导致Vue报循环引用的错误
报错截图：
![image](https://github.com/xiaocheng555/el-table-virtual-scroll/assets/29765615/05496b4b-7e54-4b95-8d95-ed8320fcd708)
